### PR TITLE
overlays/branchctl: pass revision through to the overlay

### DIFF
--- a/overlays/branchctl.nix
+++ b/overlays/branchctl.nix
@@ -2,4 +2,4 @@
 let
   branchctl = fetchGit { url = "git@github.com:iknow/branchctl"; ref = "master"; };
 in
-  import "${branchctl}/nix/overlay.nix"
+  import "${branchctl}/nix/overlay-with-rev.nix" { rev = branchctl.rev or "unknown"; }


### PR DESCRIPTION
To make `branchctl version` more helpful.